### PR TITLE
Use trapeze replace

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,29 +22,12 @@ Once the access is set up, the build processes is the same as for most Ionic app
 
 The `npm run build` command potentially modifies the following files:
 
-```
-android/app/build.gradle
+```shell
+android/variables.gradle
 android/app/src/main/AndroidManifest.xml
 ios/App/App/Info.plist
 src/config.ts
 ```
-
-Do not commit changes to the `android/app/build.gradle` file. The `trapeze` tool adds the following code to it:
-
-```diff
---- a/android/app/build.gradle
-+++ b/android/app/build.gradle
-@@ -15,6 +15,7 @@ android {
-              // Default: https://android.googlesource.com/platform/frameworks/base/+/282e181b58cf72b6ca770dc7ca5f91f135444502/tools/aapt/AaptAssets.cpp#61
-             ignoreAssetsPattern '!.svn:!.git:!.ds_store:!*.scc:.*:!CVS:!thumbs.db:!picasa.ini:!*~'
-         }
-+        manifestPlaceholders = ['AUTH_URL_SCHEME': 'msauth']
-     }
-     buildTypes {
-         release {
-```
-
-This is currently performed as an add and not an update due to [limitations in the tooling](https://github.com/ionic-team/trapeze/issues/157).
 
 Changes to the native files can be reverted to the committed content via `npm run clean`.
 

--- a/android/variables.gradle
+++ b/android/variables.gradle
@@ -13,4 +13,5 @@ ext {
     androidxJunitVersion = '1.1.5'
     androidxEspressoCoreVersion = '3.5.1'
     cordovaAndroidVersion = '10.1.1'
+    AUTH_URL_SCHEME = 'msauth'
 }

--- a/config.yaml
+++ b/config.yaml
@@ -8,9 +8,9 @@ platforms:
       - file: variables.gradle
         target:
           ext:
-        insertType: 'variable'
-        insert:
-          - AUTH_URL_SCHEME: "'$AUTH_URL_SCHEME'"
+            AUTH_URL_SCHEME:
+        replace:
+          AUTH_URL_SCHEME: "'$AUTH_URL_SCHEME'"
   ios:
     targets:
       App:


### PR DESCRIPTION
Use replace instead of insert. Gradle `replace` seems to have a couple of idiosyncrasies:
- An existing key must exist. If it doesn't, the `=` isn't written so you end up with a broken gradle.
- A default var value in the yaml seems to be required too if you're setting the value via an environment variable. If not, an empty string is written.